### PR TITLE
[HB-4105] AdMob v21

### DIFF
--- a/AdMobAdapter/build.gradle
+++ b/AdMobAdapter/build.gradle
@@ -19,7 +19,7 @@ android {
         minSdk 21
         targetSdk 32
         versionCode 1
-        versionName "2.20.6.0.0"
+        versionName "3.21.0.0.0"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
@@ -55,8 +55,10 @@ dependencies {
     // You may choose a different release version.
     // implementation 'com.chartboost:helium:2.10.0'
 
+    // Partner SDK
+    implementation 'com.google.android.gms:play-services-ads:21.0.0'
+
     implementation 'org.greenrobot:eventbus:3.3.1'
-    implementation 'com.google.android.gms:play-services-ads:20.6.0'
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.0'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.6.10"
     implementation 'androidx.appcompat:appcompat:1.4.2'

--- a/AdMobAdapter/src/main/java/com/chartboost/helium/admobadapter/AdMobAdapter.kt
+++ b/AdMobAdapter/src/main/java/com/chartboost/helium/admobadapter/AdMobAdapter.kt
@@ -58,7 +58,7 @@ class AdMobAdapter : PartnerAdapter {
      * Note that the version string will be in the format of afma-sdk-a-v221908999.214106000.1.
      */
     override val partnerSdkVersion: String
-        get() = MobileAds.getVersionString()
+        get() = MobileAds.getVersion().toString()
 
     /**
      * Get the AdMob adapter version.
@@ -272,7 +272,7 @@ class AdMobAdapter : PartnerAdapter {
                     request = request,
                 )
 
-                adview.adSize = getAdMobAdSize(request.size)
+                adview.setAdSize(getAdMobAdSize(request.size))
                 adview.adUnitId = request.partnerPlacement
                 adview.loadAd(buildRequest(request.identifier))
                 adview.adListener = object : AdListener() {


### PR DESCRIPTION
- Bump AdMob version to 21
- Updated deprecated `getVersionString` to `getVersion().toString()`
- adView.adSize could no longer be set. Using `setAdSize` method instead.