### PR TITLE
AdMob - Expose configurable field(s)

### DIFF
--- a/AdMobAdapter/src/main/java/com/chartboost/helium/admobadapter/AdMobAdapter.kt
+++ b/AdMobAdapter/src/main/java/com/chartboost/helium/admobadapter/AdMobAdapter.kt
@@ -27,7 +27,7 @@ class AdMobAdapter : PartnerAdapter {
     companion object {
         /**
          * List containing device IDs to be set for enabling AdMob test ads. It can be populated at
-         * any time and it will take effect for the next ad request. Remember to empty this list or
+         * any time and will take effect for the next ad request. Remember to empty this list or
          * stop setting it before releasing your app.
          */
         public var testDeviceIds = listOf<String>()


### PR DESCRIPTION
Google always clears out the test IDs list so as long as we call their API (with an empty or non-empty list) we should be fine here.