### PR TITLE
AdMob: Remove Helium reward from partner API

### DIFF
--- a/AdMobAdapter/src/main/java/com/chartboost/helium/admobadapter/AdMobAdapter.kt
+++ b/AdMobAdapter/src/main/java/com/chartboost/helium/admobadapter/AdMobAdapter.kt
@@ -641,7 +641,7 @@ class AdMobAdapter : PartnerAdapter {
 
                     rewardedAd.show(context) { reward ->
                         PartnerLogController.log(DID_REWARD)
-                        listener?.onPartnerAdRewarded(partnerAd, Reward(reward.amount, reward.type))
+                        listener?.onPartnerAdRewarded(partnerAd)
                             ?: PartnerLogController.log(
                                 CUSTOM,
                                 "Unable to fire onPartnerAdRewarded for AdMob adapter."


### PR DESCRIPTION
Don't merge yet. Depends upon Bichen's upcoming Helium PR.