### PR TITLE
Initialization of `MobileAds` SDK on the `IO` context.

### DIFF
--- a/AdMobAdapter/build.gradle.kts
+++ b/AdMobAdapter/build.gradle.kts
@@ -34,7 +34,7 @@ android {
         minSdk = 21
         targetSdk = 33
         // If you touch the following line, don't forget to update scripts/get_rc_version.zsh
-        android.defaultConfig.versionName = System.getenv("VERSION_OVERRIDE") ?: "4.22.3.0.5"
+        android.defaultConfig.versionName = System.getenv("VERSION_OVERRIDE") ?: "4.22.3.0.6"
 
         buildConfigField(
             "String",

--- a/AdMobAdapter/src/main/java/com/chartboost/mediation/admobadapter/AdMobAdapter.kt
+++ b/AdMobAdapter/src/main/java/com/chartboost/mediation/admobadapter/AdMobAdapter.kt
@@ -154,18 +154,16 @@ class AdMobAdapter : PartnerAdapter {
     override suspend fun setUp(
         context: Context,
         partnerConfiguration: PartnerConfiguration,
-    ): Result<Unit> {
+    ): Result<Unit> = withContext(IO) {
         PartnerLogController.log(SETUP_STARTED)
 
-        withContext(IO) {
             // Since Chartboost Mediation is the mediator, no need to initialize AdMob's partner SDKs.
             // https://developers.google.com/android/reference/com/google/android/gms/ads/MobileAds?hl=en#disableMediationAdapterInitialization(android.content.Context)
             //
             // There have been known ANRs when calling disableMediationAdapterInitialization() on the main thread.
             MobileAds.disableMediationAdapterInitialization(context)
-        }
 
-        return suspendCancellableCoroutine { continuation ->
+        return@withContext suspendCancellableCoroutine { continuation ->
             fun resumeOnce(result: Result<Unit>) {
                 if (continuation.isActive) {
                     continuation.resume(result)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 Note the first digit of every adapter version corresponds to the major version of the Chartboost Mediation SDK compatible with that adapter. 
 Adapters are compatible with any Chartboost Mediation SDK version within that major version.
 
+### 4.22.3.0.6
+- Initialization of `MobileAds` SDK on the `IO` context.
+
 ### 4.22.3.0.5
 - Fix memory leaks that could occur when fullscreen ads are shown from an `Activity`.
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The Chartboost Mediation AdMob adapter mediates AdMob via the Chartboost Mediati
 
 In your `build.gradle`, add the following entry:
 ```
-    implementation "com.chartboost:chartboost-mediation-adapter-admob:4.22.3.0.5"
+    implementation "com.chartboost:chartboost-mediation-adapter-admob:4.22.3.0.6"
 ```
 
 ## Contributions


### PR DESCRIPTION
https://chartboost.atlassian.net/browse/HB-8061

Initialization of `MobileAds` SDK on the `IO` context.

Corollary PR for Google Bidding: https://github.com/ChartBoost/chartboost-mediation-android-adapter-google-bidding/pull/70