### PR TITLE
Initialization of `MobileAds` SDK on the `IO` context for mediation 5 adapter

### DIFF
--- a/AdMobAdapter/src/main/java/com/chartboost/mediation/admobadapter/AdMobAdapter.kt
+++ b/AdMobAdapter/src/main/java/com/chartboost/mediation/admobadapter/AdMobAdapter.kt
@@ -108,7 +108,7 @@ class AdMobAdapter : PartnerAdapter {
         // There have been known ANRs when calling disableMediationAdapterInitialization() on the main thread.
         MobileAds.disableMediationAdapterInitialization(context)
 
-        return@withContext suspendCancellableCoroutine { continuation ->
+        suspendCancellableCoroutine { continuation ->
             fun resumeOnce(result: Result<Map<String, Any>>) {
                 if (continuation.isActive) {
                     continuation.resume(result)

--- a/AdMobAdapter/src/main/java/com/chartboost/mediation/admobadapter/AdMobAdapter.kt
+++ b/AdMobAdapter/src/main/java/com/chartboost/mediation/admobadapter/AdMobAdapter.kt
@@ -99,18 +99,16 @@ class AdMobAdapter : PartnerAdapter {
     override suspend fun setUp(
         context: Context,
         partnerConfiguration: PartnerConfiguration,
-    ): Result<Map<String, Any>> {
+    ): Result<Map<String, Any>> = withContext(IO) {
         PartnerLogController.log(SETUP_STARTED)
 
-        withContext(IO) {
-            // Since Chartboost Mediation is the mediator, no need to initialize AdMob's partner SDKs.
-            // https://developers.google.com/android/reference/com/google/android/gms/ads/MobileAds?hl=en#disableMediationAdapterInitialization(android.content.Context)
-            //
-            // There have been known ANRs when calling disableMediationAdapterInitialization() on the main thread.
-            MobileAds.disableMediationAdapterInitialization(context)
-        }
+        // Since Chartboost Mediation is the mediator, no need to initialize AdMob's partner SDKs.
+        // https://developers.google.com/android/reference/com/google/android/gms/ads/MobileAds?hl=en#disableMediationAdapterInitialization(android.content.Context)
+        //
+        // There have been known ANRs when calling disableMediationAdapterInitialization() on the main thread.
+        MobileAds.disableMediationAdapterInitialization(context)
 
-        return suspendCancellableCoroutine { continuation ->
+        return@withContext suspendCancellableCoroutine { continuation ->
             fun resumeOnce(result: Result<Map<String, Any>>) {
                 if (continuation.isActive) {
                     continuation.resume(result)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Adapters are compatible with any Chartboost Mediation SDK version within that ma
 - This version of the adapter has been certified with Google Mobile Ads SDK 23.1.0.
 - This version of the adapter supports Chartboost Mediation SDK version 5.+.
 
+### 4.22.3.0.6
+- Initialization of `MobileAds` SDK on the `IO` context.
+
 ### 4.22.3.0.5
 - Fix memory leaks that could occur when fullscreen ads are shown from an `Activity`.
 


### PR DESCRIPTION
https://chartboost.atlassian.net/browse/HB-8061

Initialization of MobileAds SDK on the IO context for the mediation 5 adapter.